### PR TITLE
`mattr_accessor` should be defined on the module

### DIFF
--- a/lib/simple_redlock.rb
+++ b/lib/simple_redlock.rb
@@ -3,9 +3,7 @@ require_relative 'simple_redlock/locker'
 require_relative 'simple_redlock/lockable'
 
 module SimpleRedlock
-  class << self
-    mattr_accessor :redis_url
-  end
+  mattr_accessor :redis_url
 
   def self.configure(&block)
     yield self


### PR DESCRIPTION
Rails now throws an error if this is defined on the singleton.